### PR TITLE
Removes the extraneous semicolon in the `_dialogs.sass` file. 

### DIFF
--- a/src/sass/_dialogs.sass
+++ b/src/sass/_dialogs.sass
@@ -20,7 +20,7 @@
     width: 90%
     border: 1px solid $dialog-color-border
     box-shadow: 0 19px 38px rgba(black, 0.20), 0 15px 12px rgba(black, 0.22)
-    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)
     background: white
     background: $dialog-color-footer-background
     overflow: hidden
@@ -31,7 +31,7 @@
 
     @media (min-width: $breakpoint)
         width: 500px
-    
+
 .markitup-dialog.markitup-transition
     opacity: 1
 


### PR DESCRIPTION
This was throwing errors in asset precompilation when using this node module in
rails builds.